### PR TITLE
Typo fix

### DIFF
--- a/docs/tutorials/quick-tess.py
+++ b/docs/tutorials/quick-tess.py
@@ -23,9 +23,11 @@ import lightkurve as lk
 # -
 
 # # Quick fits for TESS light curves
-
 # + active=""
-# .. note:: You will need exoplanet version 0.2.6 or later to run this tutorial.
+#
+# .. note:: 
+#
+#     You will need exoplanet version 0.2.6 or later to run this tutorial.
 # -
 
 # In this tutorial, we will fit the TESS light curve for a known transiting planet.


### PR DESCRIPTION
I think this changes a formatting bug in the note generation which should now render the note at the beginning of the [Quick fits for TESS](https://gallery.exoplanet.codes/en/latest/tutorials/quick-tess/) tutorial.