### PR TITLE
Add intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,10 @@ release = __version__
 
 exclude_patterns = ["_build"]
 
+intersphinx_mapping = {
+    "exoplanet": ("https://docs.exoplanet.codes/en/latest/", None),
+}
+
 # HTML theme
 html_theme = "sphinx_book_theme"
 html_copy_source = True


### PR DESCRIPTION
This will fix the pink missing cross-references like `exoplanet.estimate_semi_amplitude` in https://gallery.exoplanet.codes/tutorials/rv/ or `exoplanet.distributions.QuadLimbDark` in https://gallery.exoplanet.codes/tutorials/transit/#the-transit-model-in-pymc3